### PR TITLE
FIX: when paused, reheat will wait for unheated nozzle

### DIFF
--- a/Marlin/UltiLCD2_menu_print.cpp
+++ b/Marlin/UltiLCD2_menu_print.cpp
@@ -1432,6 +1432,13 @@ void lcd_print_pause()
             zdiff = 2;
         }
 
+        // This should really in M601... but for unknown reason
+        // backup_temperature only declared in lcd related headers...
+        // in case we resume print and backup temperature has a stalled value
+        for (int e = 0; e < EXTRUDERS; e++) {
+            backup_temperature[e] = target_temperature[e];
+        }
+
         char buffer[32] = {0};
         char buffer_len[10];
     #if (EXTRUDERS > 1)


### PR DESCRIPTION
When resuming from pause, check_pause() will check if the nozzle has been turned off by heater timeout.
But it doesn't really "remember" if the nozzle was turned off by timeout or was not been in the first place.

If the backup_temperature which was used to store the temperature when heater timeout kicked in.
That temperature will be stored, and during resume phase, the stored temperature will be set back.

This patch fixes this issue by refresh the backup_temperature variable on pausing.

Jia